### PR TITLE
Fix Issue #5

### DIFF
--- a/src/main/java/io/qiot/covid19/datahub/registration/certmanager/client/CertificateOperation.java
+++ b/src/main/java/io/qiot/covid19/datahub/registration/certmanager/client/CertificateOperation.java
@@ -2,7 +2,6 @@ package io.qiot.covid19.datahub.registration.certmanager.client;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.function.Consumer;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -109,14 +108,17 @@ public class CertificateOperation {
                             .inNamespace(namespace)
                             .withName(resource.getSpec().getSecretName())
                             .get();
-            
-                        RegisterResponse registerResponse = RegisterResponse.builder()
-                            .keystore(secret.getData().get(KeystoreSpec.KEYSTORE_KEY_P12))
-                            .truststore(secret.getData().get(KeystoreSpec.TRUSTSTORE_KEY_P12))
-                        .build();
-                        em.complete(registerResponse);
-                        LOGGER.debug("Certificate {} is ready: {}", name, resource);
-                        watch.close();
+                        String keystore = secret.getData().get(KeystoreSpec.KEYSTORE_KEY_P12);
+                        String truststore = secret.getData().get(KeystoreSpec.TRUSTSTORE_KEY_P12);
+                        if(keystore != null && truststore != null) {
+                            RegisterResponse registerResponse = RegisterResponse.builder()
+                                .keystore(keystore)
+                                .truststore(truststore)
+                            .build();
+                            em.complete(registerResponse);
+                            LOGGER.debug("Certificate {} is ready: {}", name, resource);
+                            watch.close();
+                        }
                     }
                 }
             }

--- a/src/main/java/io/qiot/covid19/datahub/registration/rest/RegisterResource.java
+++ b/src/main/java/io/qiot/covid19/datahub/registration/rest/RegisterResource.java
@@ -57,16 +57,19 @@ public class RegisterResource {
 //        Set<ConstraintViolation<RegisterRequest>> violations = validator.validate(data);
 //        if (!violations.isEmpty()) throw new ValidationException(Arrays.deepToString(violations.toArray()));
 
-        RegisterResponse response = certificateService.provision(data);
+        final String stationId = stationServiceClient.add(data.getSerial(), data.getName(), data.getLongitude(), data.getLatitude());
+        LOGGER.debug(
+                "Successfully provisioned a new station ID ({}) for the registration request \n{}",
+                stationId, data);
+
+        RegisterResponse response = certificateService.provision(data, stationId);
+        
         LOGGER.debug(
                 "Successfully provisioned certificates for the registration request \n{}",
                 data);
 
-        response.setId(stationServiceClient.add(data.getSerial(),
-                data.getName(), data.getLongitude(), data.getLatitude()));
-        LOGGER.debug(
-                "Successfully provisioned a new station ID ({}) for the registration request \n{}",
-                response.getId(), data);
+        response.setId(stationId);
+
 
         LOGGER.debug("Create response: {}", response);
         return response;

--- a/src/main/java/io/qiot/covid19/datahub/registration/service/CertificateService.java
+++ b/src/main/java/io/qiot/covid19/datahub/registration/service/CertificateService.java
@@ -14,6 +14,6 @@ import io.qiot.covid19.datahub.registration.rest.beans.RegisterResponse;
  **/
 public interface CertificateService {
 
-    public RegisterResponse provision(RegisterRequest registerRequest)
+    public RegisterResponse provision(RegisterRequest registerRequest, String id)
             throws CertificateProvisionException;
 }

--- a/src/main/java/io/qiot/covid19/datahub/registration/service/impl/CertManagerCertificateService.java
+++ b/src/main/java/io/qiot/covid19/datahub/registration/service/impl/CertManagerCertificateService.java
@@ -54,10 +54,10 @@ public class CertManagerCertificateService implements CertificateService {
     }
 
     @Override
-    public RegisterResponse provision(RegisterRequest data)
+    public RegisterResponse provision(RegisterRequest data, String id)
             throws CertificateProvisionException {
-        final String name = data.getName();
-        final String commonName = name + "."
+        final String name = id; // unique name
+        final String commonName = data.getName() + "."
                 + certificateOperation.getNamespace() + domain;
 
         final Certificate certificate = Certificate.builder()
@@ -70,7 +70,7 @@ public class CertManagerCertificateService implements CertificateService {
                         .dnsNames(Arrays.asList(new String[] { commonName }))
                         .issuerRef(ObjectReferenceSpec.builder().name(issuer)
                                 .build())
-                        .keystores(createKeyStoreSecret(data)).build())
+                        .keystores(createKeyStoreSecret(data, id)).build())
                 .build();
 
         certificateOperation.operation().create(certificate);
@@ -81,12 +81,12 @@ public class CertManagerCertificateService implements CertificateService {
     }
 
     private CertificateKeystoresSpec
-            createKeyStoreSecret(RegisterRequest data) {
+            createKeyStoreSecret(RegisterRequest data, String id) {
 
         final String keyStorePassword = data.getKeyStorePassword();
 
         if (keyStorePassword != null && !"".equals(keyStorePassword)) {
-            String secretName = KEYSTORE_SECRET_PREFIX + data.getName();
+            String secretName = KEYSTORE_SECRET_PREFIX + id;
 
             LOGGER.debug("Secret Keystore creation {} ", secretName);
 

--- a/src/main/java/io/qiot/covid19/datahub/registration/service/impl/DefaultCertificateService.java
+++ b/src/main/java/io/qiot/covid19/datahub/registration/service/impl/DefaultCertificateService.java
@@ -34,7 +34,7 @@ public class DefaultCertificateService implements CertificateService {
     }
 
     @Override
-    public RegisterResponse provision(RegisterRequest data)
+    public RegisterResponse provision(RegisterRequest data, String id)
             throws CertificateProvisionException {
 
         ClassLoader loader = Thread.currentThread().getContextClassLoader();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,7 +12,6 @@ quarkus.swagger-ui.always-include=true
 station-api/mp-rest/url=${STATION-SERVICE-URL\:http\://localhost:5033} 
 station-api/mp-rest/scope=javax.inject.Singleton
 
-quarkus.kubernetes-client.namespace=covid19-dev
 quarkus.kubernetes-client.trust-certs=true
 
 qiot.cert-manager.issuer=vault-covid19-issuer-vault
@@ -36,6 +35,7 @@ quarkus.http.insecure-requests=disabled
 # Dev
 %dev.quarkus.http.port=5016
 %dev.qiot.cert-manager.enabled=${CERT_MANAGER_ENABLED\:false}
+
 
 # Test
 %test.qiot.cert-manager.enabled=${CERT_MANAGER_ENABLED\:false}


### PR DESCRIPTION
* Invert call order: 1st station service and 2nd certificate
* Using station UUID as resource name.
* Minor improvement:
  * Avoid NullPoint when keystore and truststore are not yet available
  * Removed windows character return code on application.properties